### PR TITLE
fix autoescape overeagerly escaping highlight output

### DIFF
--- a/jinja2_highlight/highlight.py
+++ b/jinja2_highlight/highlight.py
@@ -56,6 +56,6 @@ class HighlightExtension(Extension):
             sys.exit(1)
 
         formatter = HtmlFormatter()
-        code = highlight(body, lexer, formatter)
-        return Markup(code).unescape()
+        code = highlight(Markup(body).unescape(), lexer, formatter)
+        return code
 


### PR DESCRIPTION
in a situation where autoescape is on, the fix for this is to

``` jinja
{% autoescape false %}
{% highlight 'python' %}
...
{% endighlight %}
{% endautoescape %}
```

this patch wraps the `body` as Markup  before sending it off to pygments territory, eliminating the need for the autoescape block so that you can do...

``` jinja
{% highlight 'python' %}
...
{% endighlight %}
```

also, maybe this is the wrong way to do this! if so, many apologies.

thanks for the extension!
