### PR TITLE
Line numbering and cssclass support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,12 +58,14 @@ Optional settings
 By default Pygments renders the code block inside a div with the class 'highlight', if you want to change the name you can set the environment variable `jinja2_highlight_cssclass` to the class name you would like.
 
 In jinja this can be done after you've created your environment;
+::
 
     env = Environment(extensions=['jinja2_highlight.HighlightExtension'])
     # Set the css class name to 'codehilite'
     env.extend(jinja2_highlight_cssclass = 'codehilite')
 
 In Flask this can be done with the following (after creating your app):
+::
 
     app.jinja_env.extend(jinja2_highlight_divname = 'codehilite')
 

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ In jinja this can be done after you've created your environment;
 In Flask this can be done with the following (after creating your app):
 ::
 
-    app.jinja_env.extend(jinja2_highlight_divname = 'codehilite')
+    app.jinja_env.extend(jinja2_highlight_cssclass = 'codehilite')
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Requirements
 * Pygments >= 1.5
 
 
-Highlight example
+Highlight examples
 =================
 ::
 
@@ -35,6 +35,38 @@ Highlight example
     {% endhighlight %}
 
 Replace `language` with the appropriate Pygments lexer short name: http://pygments.org/docs/lexers/
+
+Line numbering can be turned on using `lineno='inline'` or `lineno='table'` depending on the style of line numbering you want (as per Pygment's documentation: http://pygments.org/docs/formatters/#HtmlFormatter)
+
+::
+
+    {% highlight 'language', lineno='inline' %}
+    your-awesome-code-here
+    {% endhighlight %}
+
+This can also be used without a language setting
+
+::
+
+    {% highlight lineno='table' %}
+    your-awesome-code-here
+    {% endhighlight %}
+
+Optional settings
+================
+
+By default Pygments renders the code block inside a div with the class 'highlight', if you want to change the name you can set the environment variable `jinja2_highlight_cssclass` to the class name you would like.
+
+In jinja this can be done after you've created your environment;
+
+    env = Environment(extensions=['jinja2_highlight.HighlightExtension'])
+    # Set the css class name to 'codehilite'
+    env.extend(jinja2_highlight_cssclass = 'codehilite')
+
+In Flask this can be done with the following (after creating your app):
+
+    app.jinja_env.extend(jinja2_highlight_divname = 'codehilite')
+
 
 
 Using with Flask

--- a/examples/flask/flask-example.py
+++ b/examples/flask/flask-example.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from flask import Flask, render_template, url_for
+from flask.helpers import locked_cached_property
 import jinja2_highlight
 
 class MyFlask(Flask):
@@ -7,7 +8,18 @@ class MyFlask(Flask):
     jinja_options.setdefault('extensions',
         []).append('jinja2_highlight.HighlightExtension')
 
+    # If you'd like to set the class name of the div code blocks are rendered in
+    # Uncomment the below lines otherwise the option below can be used
+    #@locked_cached_property
+    #def jinja_env(self):
+    #    jinja_env = self.create_jinja_environment()
+    #    jinja_env.extend(jinja2_highlight_cssclass = 'codehilite')
+    #    return jinja_env
+
 app = MyFlask(__name__)
+
+# The second way to set the cssclass name for jinja2_highlight
+#app.jinja_env.extend(jinja2_highlight_cssclass = 'codehilite')
 
 @app.route('/')
 def index():

--- a/examples/flask/static/code.css
+++ b/examples/flask/static/code.css
@@ -1,5 +1,5 @@
 /* railcasts.css
- * https://github.com/uraimo/pygments-vimstyles/blob/2a99e97f6383d1b978917ff42f9ecdd6b2f021c0/railscasts.css 
+ * https://github.com/uraimo/pygments-vimstyles/blob/2a99e97f6383d1b978917ff42f9ecdd6b2f021c0/railscasts.css
  */
 
 .highlight  { background: #2B2B2B; color: #E6E1DC}

--- a/examples/flask/templates/index.html
+++ b/examples/flask/templates/index.html
@@ -14,6 +14,28 @@ from fridge import Beer
 glass = Beer(lt=500)
 glass.drink()
 {% endhighlight %}
+    </div>
+    <div>
+        Here's an example with inline line numbering.
+    </div>
+    <div>
+{% highlight 'python', lineno='inline' %}
+from fridge import Beer
+
+glass = Beer(lt=500)
+glass.drink()
+{% endhighlight %}
+    </div>
+    <div>
+        Here's an example with tabled line numbering.
+    </div>
+    <div>
+{% highlight 'python', lineno='table' %}
+from fridge import Beer
+
+glass = Beer(lt=500)
+glass.drink()
+{% endhighlight %}
         </div>
     </body>
 </html>

--- a/jinja2_highlight/highlight.py
+++ b/jinja2_highlight/highlight.py
@@ -110,9 +110,10 @@ class HighlightExtension(Extension):
 
         # Check the globals to see if a cssclass setting for Pygment's HtmlFormatter
         # has been set
-        if 'jinja2_highlight_cssclass' in self.environment.globals:
-            cssclass = self.environment.globals['jinja2_highlight_cssclass']
-        else:
+
+        try:
+            cssclass = self.environment.jinja2_highlight_cssclass
+        except AttributeError:
             cssclass = None
 
         try:
@@ -140,6 +141,6 @@ class HighlightExtension(Extension):
         # The result will have an extra blank line underneath, use strip
         # to remove extraneous white space? Will this cause issues?
         # Maybe just use rstrip instead?
-        code = highlight(Markup(body.strip()).unescape(), lexer, formatter)
+        code = highlight(Markup(body.rstrip()).unescape(), lexer, formatter)
         return code
 

--- a/jinja2_highlight/highlight.py
+++ b/jinja2_highlight/highlight.py
@@ -10,7 +10,7 @@ from pygments.formatters import HtmlFormatter
 from pygments.util import ClassNotFound
 
 class HighlightExtension(Extension):
-    """Highlight code blocks using Pygments
+    """Highlight code blocks using Pygments.
 
     Example::
 
@@ -22,19 +22,31 @@ class HighlightExtension(Extension):
         pint_glass.drink()
 
         {% endhighlight %}
+
+    Line numbers can be turned in if True is passed in addition to the language.
+
+        {% highlight 'python', True %}
+
+        from fridge import Beer
+
+        pint_glass = Beer()
+        pint_glass.drink()
+
+        {% endhighlight %}
     """
     tags = set(['highlight'])
 
+    # TO DO: What if they want line numbers but don't pass the language?
+    # E.g. {% highlight True %}
+
     def parse(self, parser):
         lineno = next(parser.stream).lineno
-
-        # TODO:
-        # add support to show line numbers
 
         # extract the language if available
         if not parser.stream.current.test('block_end'):
             args = [parser.parse_expression()]
 
+            # If there's a comma, get the next argument
             if parser.stream.skip_if('comma'):
                 args.append(parser.parse_expression())
             else:
@@ -73,6 +85,12 @@ class HighlightExtension(Extension):
             formatter = HtmlFormatter(cssclass=cssclass, linenos=linenos)
         else:
             formatter = HtmlFormatter(linenos=linenos)
-        code = highlight(Markup(body).unescape(), lexer, formatter)
+        # If you place the tag on the line under the code, like this;
+        # pint_glass.drink()
+        # {% endhighlight %}
+        # The result will have an extra blank line underneath, use strip
+        # to remove extraneous white space? Will this cause issues?
+        # Maybe just use rstrip instead?
+        code = highlight(Markup(body.strip()).unescape(), lexer, formatter)
         return code
 

--- a/jinja2_highlight/highlight.py
+++ b/jinja2_highlight/highlight.py
@@ -134,8 +134,9 @@ class HighlightExtension(Extension):
         # If you place the tag on the line under the code, like this;
         # pint_glass.drink()
         # {% endhighlight %}
-        # The result will have an extra blank line underneath, use rstrip
-        # to remove extraneous white space? Will this cause issues?
+        # The result will have an extra blank line underneath, this can cause an extra
+        # blank line of line numbering.
+        # Use rstrip to remove extraneous white space? Will this cause issues?
         code = highlight(Markup(body.rstrip()).unescape(), lexer, formatter)
         return code
 

--- a/jinja2_highlight/highlight.py
+++ b/jinja2_highlight/highlight.py
@@ -52,7 +52,7 @@ class HighlightExtension(Extension):
 
         # extract the language and line numbering setting if available
         if not parser.stream.current.test('block_end'):
-            # If first up we have line number setting, lineno='inline', work with that
+            # If first up we have an assignment, e.g. lineno='inline', work with that
             if parser.stream.current.type == 'name':
                 name = parser.stream.expect('name')
                 # If the assign is lineno
@@ -61,7 +61,7 @@ class HighlightExtension(Extension):
                         # Assume no language and then add the assigned line number setting
                         args = [nodes.Const(None)]
                         args.append(parser.parse_expression())
-                # If it's not a lineno, ignore it
+                # If it's not a lineno assignment, ignore it
                 else:
                     if parser.stream.skip_if('assign'):
                         next(parser.stream)

--- a/jinja2_highlight/highlight.py
+++ b/jinja2_highlight/highlight.py
@@ -47,9 +47,6 @@ class HighlightExtension(Extension):
     """
     tags = set(['highlight'])
 
-    # TO DO: What if they want line numbers but don't pass the language?
-    # E.g. {% highlight True %}
-
     def parse(self, parser):
         lineno = next(parser.stream).lineno
 
@@ -110,7 +107,6 @@ class HighlightExtension(Extension):
 
         # Check the globals to see if a cssclass setting for Pygment's HtmlFormatter
         # has been set
-
         try:
             cssclass = self.environment.jinja2_highlight_cssclass
         except AttributeError:
@@ -138,9 +134,8 @@ class HighlightExtension(Extension):
         # If you place the tag on the line under the code, like this;
         # pint_glass.drink()
         # {% endhighlight %}
-        # The result will have an extra blank line underneath, use strip
+        # The result will have an extra blank line underneath, use rstrip
         # to remove extraneous white space? Will this cause issues?
-        # Maybe just use rstrip instead?
         code = highlight(Markup(body.rstrip()).unescape(), lexer, formatter)
         return code
 

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -116,6 +116,33 @@ class HighlightExtensionTestCase(unittest.TestCase):
 
         assert tpl.render().split() == self.inline_no_lang_rendered
 
+    table_no_lang_rendered = [
+                u'<table',
+                u'class="highlighttable"><tr><td',
+                u'class="linenos"><div',
+                u'class="linenodiv"><pre>1</pre></div></td><td',
+                u'class="code"><div',
+                u'class="highlight"><pre>',
+                u'<span',
+                u'class="n">print</span><span',
+                u'class="p">(</span><span',
+                u'class="s">&quot;Hello',
+                u'world&quot;</span><span',
+                u'class="p">)</span>',
+                u'</pre></div>',
+                u'</td></tr></table>'
+            ]
+
+    def test_python_tpl_with_table_no_lang(self):
+        env = Environment(extensions=['jinja2_highlight.HighlightExtension'])
+        tpl = env.from_string('''
+            {% highlight lineno="table" %}
+               print("Hello world")
+            {% endhighlight %}
+        ''')
+
+        assert tpl.render().split() == self.table_no_lang_rendered
+
     cssclass_rendered = [
                 u'<div',
                 u'class="codehilite"><pre>',

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -41,3 +41,101 @@ class HighlightExtensionTestCase(unittest.TestCase):
         ''')
 
         assert tpl.render().split() == self.rendered
+
+    inline_rendered = [
+                u'<div',
+                u'class="highlight"><pre>'
+                u'<span',
+                u'class="lineno">1</span>',
+                u'<span',
+                u'class="k">print</span><span',
+                u'class="p">(</span><span',
+                u'class="s">&quot;Hello',
+                u'world&quot;</span><span',
+                u'class="p">)</span>',
+                u'</pre></div>'
+            ]
+
+    def test_python_tpl_with_inline(self):
+        env = Environment(extensions=['jinja2_highlight.HighlightExtension'])
+        tpl = env.from_string('''
+            {% highlight "python", lineno="inline" %}
+               print("Hello world")
+            {% endhighlight %}
+        ''')
+
+        assert tpl.render().split() == self.inline_rendered
+
+    table_rendered = [
+                u'<table',
+                u'class="highlighttable"><tr><td',
+                u'class="linenos"><div',
+                u'class="linenodiv"><pre>1</pre></div></td><td',
+                u'class="code"><div',
+                u'class="highlight"><pre>',
+                u'<span',
+                u'class="k">print</span><span',
+                u'class="p">(</span><span',
+                u'class="s">&quot;Hello',
+                u'world&quot;</span><span',
+                u'class="p">)</span>',
+                u'</pre></div>',
+                u'</td></tr></table>'
+            ]
+
+    def test_python_tpl_with_table(self):
+        env = Environment(extensions=['jinja2_highlight.HighlightExtension'])
+        tpl = env.from_string('''
+            {% highlight "python", lineno="table" %}
+               print("Hello world")
+            {% endhighlight %}
+        ''')
+
+        assert tpl.render().split() == self.table_rendered
+
+    inline_no_lang_rendered = [
+                u'<div',
+                u'class="highlight"><pre><span',
+                u'class="lineno">1</span>',
+                u'<span',
+                u'class="n">print</span><span',
+                u'class="p">(</span><span',
+                u'class="s">&quot;Hello',
+                u'world&quot;</span><span',
+                u'class="p">)</span>',
+                u'</pre></div>'
+            ]
+
+    def test_python_tpl_with_inline_no_lang(self):
+        env = Environment(extensions=['jinja2_highlight.HighlightExtension'])
+        tpl = env.from_string('''
+            {% highlight lineno="inline" %}
+               print("Hello world")
+            {% endhighlight %}
+        ''')
+
+        assert tpl.render().split() == self.inline_no_lang_rendered
+
+    cssclass_rendered = [
+                u'<div',
+                u'class="codehilite"><pre>',
+                u'<span',
+                u'class="k">print</span><span',
+                u'class="p">(</span><span',
+                u'class="s">&quot;Hello',
+                u'world&quot;</span><span',
+                u'class="p">)</span>',
+                u'</pre></div>'
+            ]
+
+    def test_python_tpl_with_cssclass(self):
+        env = Environment(extensions=['jinja2_highlight.HighlightExtension'])
+        env.extend(jinja2_highlight_cssclass = 'codehilite')
+        #env.globals['jinja2_highlight_cssclass'] = 'codehilite'
+        tpl = env.from_string('''
+            {% highlight "python" %}
+               print("Hello world")
+            {% endhighlight %}
+        ''')
+
+        assert tpl.render().split() == self.cssclass_rendered


### PR DESCRIPTION
Hi Tasos,

I've added support for Pygment's HtmlFormatter's line numbering (both inline and table line numbering can be used) and I've also added support to set the CSS class used by Pygments. I've updated the unit tests and the example as well. 

![linenumbering-example](https://cloud.githubusercontent.com/assets/2785496/3335950/c45962dc-f81f-11e3-9734-823e54435f40.png)

Line numbering can be set in the highlight tag by putting in `lineno='inline'` or `lineno='table'`. The cssclass can be appending `jinja2_highlight_cssclass` to the jinja2 environment and setting it's value to the CSS class name you would like. Both line numbering and CSS class are optional and from my tests jinja2_highlight will continue to work fine if both are not used, line numbering can also be used without specifying the language.

In regards to the example, I'm not entirely sure if the way I've added jinja2_highlight_cssclass to the jinja2 environment in the MyFlask class is entirely correct or in best practices. It does work though...  The second way I mentioned setting it (`app.jinja_env.extend(jinja2_highlight_cssclass = 'codehilite')`) is what I'm using personally though.

If there's anything else you'd like me to do with these changes please let me know.

Thanks,
- Jordan
