### PR TITLE
Fallback to plaintext if lexer fails

### DIFF
--- a/jinja2_highlight/highlight.py
+++ b/jinja2_highlight/highlight.py
@@ -6,6 +6,7 @@ from jinja2.ext import Extension, Markup
 
 from pygments import highlight
 from pygments.lexers import get_lexer_by_name, guess_lexer
+from pygments.lexers.special import TextLexer
 from pygments.formatters import HtmlFormatter
 from pygments.util import ClassNotFound
 
@@ -118,8 +119,8 @@ class HighlightExtension(Extension):
             else:
                 lexer = get_lexer_by_name(lang, stripall=False)
         except ClassNotFound as e:
-            print(e)
-            sys.exit(1)
+            # default to the plaintext lexer
+            lexer = TextLexer()
 
         # Set the cssclass if we have one
         # The linenos setting expects either 'inline' or 'table', as per Pygment's

--- a/tests/test_highlight.py
+++ b/tests/test_highlight.py
@@ -166,3 +166,22 @@ class HighlightExtensionTestCase(unittest.TestCase):
         ''')
 
         assert tpl.render().split() == self.cssclass_rendered
+
+    plaintext_rendered = [
+        u'<div',
+        u'class="highlight"><pre>',
+        u'abcdefg',
+        u'</pre></div>'
+    ]
+
+    def test_unrecognized_language_defaults_to_plaintext(self):
+        env = Environment(extensions=['jinja2_highlight.HighlightExtension'])
+
+        # Unrecognized language
+        tpl = env.from_string('''
+            {% highlight %}
+               abcdefg
+            {% endhighlight %}
+        ''')
+
+        assert tpl.render().split() == self.plaintext_rendered


### PR DESCRIPTION
My site would 500 if the lexer couldn't guess the language. I think rendering plaintext is more stable behavior for users.
